### PR TITLE
Improve the reclass_data_source ID declaration

### DIFF
--- a/reclass/storage/data.sls
+++ b/reclass/storage/data.sls
@@ -8,12 +8,11 @@ reclass_data_source:
   - name: {{ storage.data_source.address }}
   - target: {{ storage.base_dir }}
   - reload_pillar: True
-  {%- if grains.saltversioninfo.0 >= 2015.8 %}
-  - rev: HEAD
-  - branch: {{ storage.data_source.branch }}
-  {%- else %}
-  - rev: {{ storage.data_source.branch }}
+  - rev: {{ storage.data_source.revision|default(storage.data_source.branch) }}
+  {%- if grains.saltversion >= "2015.8.0" %}
+  - branch: {{ storage.data_source.branch|default(storage.data_source.revision) }}
   {%- endif %}
+  - force_reset: {{ storage.data_source.force_reset|default(False) }}
 
 {%- endif %}
 


### PR DESCRIPTION
This commit does two changes to the reclass_data_source ID declaration:
- the git.latest "rev" and "branch" expressions are changed to be consistent
  with what's done in salt-formula-salt [*].
- the "force_reset" parameter is added. This parameter is required to be able
  to use specfic branches of the model repo.

[*] https://github.com/tcpcloud/salt-formula-salt/blob/0b33d6717ef7766eb0031ad6503eede620d249fb/salt/master/env.sls#L150-L168

Fixes #1 
