### PR TITLE
fix, case reclass.storage.node is not defined

### DIFF
--- a/reclass/storage/node.sls
+++ b/reclass/storage/node.sls
@@ -4,7 +4,7 @@
 {{ storage.base_dir }}/nodes/_generated:
   file.directory
 
-{%- for node_name, node in storage.node.iteritems() %}
+{%- for node_name, node in storage.get('node', {}).iteritems() %}
 
 {%- if node.repeat is defined %}
 


### PR DESCRIPTION
found during bootstrap when model is missing node definition. required by CI