### PR TITLE
reclass.storage.node: Merge duplicate nodes

### DIFF
--- a/reclass/storage/node.sls
+++ b/reclass/storage/node.sls
@@ -13,7 +13,24 @@
     - clean: True
 {%- endif %}
 
+{%- set storage_by_name = {} %}
+
 {%- for node_name, node in storage.get('node', {}).iteritems() %}
+
+{%- if node.name is defined and node.repeat is not defined %}
+{%- set node_name = node.name %}
+
+{%- if node_name in storage_by_name and storage_by_name[node_name].classes is defined %}
+{%- do node.update({'classes': storage_by_name[node_name].classes + node.get('classes', []) }) %}
+{%- endif %}
+
+{%- endif %}
+
+{%- do salt['defaults.merge'](storage_by_name, {node_name: node}) %}
+
+{%- endfor %}
+
+{%- for node_name, node in storage_by_name.iteritems() %}
 
 {%- if node.repeat is defined %}
 

--- a/tests/pillar/storage_nodes_squash.sls
+++ b/tests/pillar/storage_nodes_squash.sls
@@ -1,0 +1,14 @@
+reclass:
+  storage:
+    enabled: true
+    node:
+      service_node01:
+        name: svc01
+        domain: deployment.local
+        classes:
+        - cluster.deployment_name.service.role
+      service_node02:
+        name: svc01
+        domain: deployment.local
+        classes:
+        - cluster.deployment_name.service.role2


### PR DESCRIPTION
Reclass does not support duplicate nodes in top pillar, so merge all
nodes with the same name into a single node, inheriting classes from
all instances.

This allows using multiple "system.reclass.storage.system.*_cluster"
classes for the same node, based on re-using the name (hostname); by
simply overriding the hostname parameters, e.g.:
  openstack_gateway_node01_hostname: ctl01

NOTE: defaults.merge module does not merge lists (e.g. for classes),
so handle that case separately. Also, leave repeated nodes alone.

--
This is a refined version of [1], which we use for a "no virtualized control plane" cluster in OPNFV (for smaller AArch64 boards that work better when control plane is directly on baremetal). To leverage it, we just override the hostnames of otherwise virtualized hosts to 'kvm{01,02,03}'.
The change should not affect current bevahior for existing clusters.

[1] https://github.com/opnfv/fuel/blob/master/mcp/patches/0014-reclass.storage.node-Merge-duplicate-nodes.patch